### PR TITLE
README: move Station64 ahead of VAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ as it has its own protocol. Currently known applications are:
 | --- | --- | --- |
 | [SID Wizard 1.8.7](https://github.com/anarkiwi/sid-wizard/releases) / [M64 SID Wizard](https://github.com/M64GitHub/sid-wizard-vessel) | Native C64 music tracker with live-performance MIDI sync | Receives external MIDI clock; uses Vessel's NMI-on-MIDI-clock to run playback precisely synchronized to external gear |
 | [defMONV](https://github.com/anarkiwi/defmonv/releases) | Patched defMON C64 music tracker that acts as a MIDI clock master | Sends MIDI clock ($F8), start ($FA) and stop ($FC) over Vessel to sync external gear, replacing defMON's ScannerBoy sync |
+| [Station64 V2.6](https://csdb.dk/release/?id=207214) | C64 MIDI tracker/performance station | MIDI input and output |
 | [Vessel ASID Player](https://github.com/anarkiwi/vap/releases) | Turns the C64's SID(s) into a remote ASID synthesis device | Receives MIDI SysEx (ASID protocol) to write SID registers; supports dual SID |
-| [Station64 V2.6](https://csdb.dk/release/?id=207214) | C64 MIDI sequencer/performance station | MIDI input and output |
 | [Vicficken](https://github.com/anarkiwi/vvf/releases) | MIDI-controlled port of the Vicficken synth | Receives MIDI to drive all synth parameters (replacing joystick/paddle/keyboard) |
 | [Vessel MIDI Player](https://github.com/anarkiwi/vmp/releases) | Turns the C64's SID(s) into a multi-voice MIDI synth | Receives notes, pitchbend and CC across channels; relies on Vessel's large buffers, CIA parallel transfer and MIDI message filtering |
 | [Vesselmon](https://github.com/anarkiwi/vessel) | Reference test/monitor program in the Vessel repository | Configures Vessel and exercises raw MIDI send/receive (including loopback) and device detection |


### PR DESCRIPTION
Station64 is a tracker, so move it up with the other tracker apps (SID Wizard, defMONV) ahead of the Vessel ASID Player. Also relabels it "tracker/performance station".

🤖 Generated with [Claude Code](https://claude.com/claude-code)