### PR TITLE
docs: bump SID Wizard to 1.97, clarify polled vs NMI forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ as it has its own protocol. Currently known applications are:
 
 | Application | What it is | Vessel functionality used |
 | --- | --- | --- |
-| [SID Wizard 1.8.7](https://github.com/anarkiwi/sid-wizard/releases) / [M64 SID Wizard](https://github.com/M64GitHub/sid-wizard-vessel) | Native C64 music tracker with live-performance MIDI sync | Receives external MIDI clock; uses Vessel's NMI-on-MIDI-clock to run playback precisely synchronized to external gear |
+| [SID Wizard 1.97](https://github.com/anarkiwi/sid-wizard/releases) / [M64 SID Wizard](https://github.com/M64GitHub/sid-wizard-vessel) | Native C64 music tracker with live-performance MIDI sync | Receives external MIDI clock to sync playback to external gear. The anarkiwi fork (now based on SID Wizard 1.97) polls MIDI each frame; the M64 fork uses Vessel's NMI-on-MIDI-clock for tighter sync |
 | [defMONV](https://github.com/anarkiwi/defmonv/releases) | Patched defMON C64 music tracker that acts as a MIDI clock master | Sends MIDI clock ($F8), start ($FA) and stop ($FC) over Vessel to sync external gear, replacing defMON's ScannerBoy sync |
 | [Station64 V2.6](https://csdb.dk/release/?id=207214) | C64 MIDI tracker/performance station | MIDI input and output |
 | [Vessel ASID Player](https://github.com/anarkiwi/vap/releases) | Turns the C64's SID(s) into a remote ASID synthesis device | Receives MIDI SysEx (ASID protocol) to write SID registers; supports dual SID |

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -28,6 +28,9 @@ applications, driving Vessel in deliberately different ways, are covered:
   NMI-status-only). Covers that a MIDI clock is forwarded *and* pulses /FLAG
   while channel messages are suppressed. Protocol read from its open ACME
   source; see [`../test/sidwizard/PROTOCOL.md`](../test/sidwizard/PROTOCOL.md).
+  The polled [anarkiwi/sid-wizard](https://github.com/anarkiwi/sid-wizard) fork
+  (SID Wizard 1.97) carries a mirror of these tests on the SID-Wizard side,
+  asserting the bytes it emits with a 6502 simulator.
 
 These run in the same suite with no extra dependencies, so a firmware change
 that breaks either application fails CI. (A heavier optional lane could

--- a/test/sidwizard/PROTOCOL.md
+++ b/test/sidwizard/PROTOCOL.md
@@ -10,6 +10,16 @@ Unlike Station64 (see `../station64/PROTOCOL.md`), SID Wizard is open source, so
 this was read directly from the ACME assembly — no decrunching/emulation needed.
 Source references below are to that repo.
 
+> There is a second Vessel fork,
+> [anarkiwi/sid-wizard](https://github.com/anarkiwi/sid-wizard) (now based on
+> SID Wizard 1.97). It **polls** MIDI each frame instead of using
+> NMI-on-MIDI-clock, so it sends the same device-open handshake (sections 1
+> below) but not the `FD 04 09` NMI config. That fork carries its own mirror of
+> these tests on the SID-Wizard side — it runs its real 6502 routines on a 6502
+> simulator and asserts the bytes it emits — in its `test/sidwizard/`
+> (`run_protocol_test.py`, `PROTOCOL.md`). The two suites pin opposite ends of
+> the same wire.
+
 ## What makes it different from Station64
 
 | | Station64 | SID Wizard |


### PR DESCRIPTION
The [anarkiwi/sid-wizard](https://github.com/anarkiwi/sid-wizard) Vessel fork was rebased onto upstream **SID-Wizard 1.97** and released as `v1.9.7`. Documentation updates only:

- **README.md**: bump the app-table entry `SID Wizard 1.8.7` → `1.97`; clarify that the anarkiwi fork polls MIDI each frame while the M64 fork uses NMI-on-MIDI-clock.
- **docs/TESTS.md** & **test/sidwizard/PROTOCOL.md**: note the two forks share the same device-open handshake (the M64 fork additionally sends `FD 04 09` for NMI sync), and cross-reference the anarkiwi fork's new SID-Wizard-side mirror of the `SidWizard*` protocol tests (a 6502-simulator harness asserting the bytes it emits).

No firmware or test code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)